### PR TITLE
feature/accurate-scoring-onload-fix

### DIFF
--- a/js/multichoice.js
+++ b/js/multichoice.js
@@ -462,8 +462,6 @@ H5P.MultiChoice = function (options, contentId, contentData) {
     }
   };
 
-  //Create question DOM on instantiation to calculate score accurately
-  this.registerDomElements();
 
   this.showAllSolutions = function () {
     if (solutionsVisible) {
@@ -1118,6 +1116,10 @@ H5P.MultiChoice = function (options, contentId, contentData) {
   this.getTitle = function () {
     return H5P.createTitle((this.contentData && this.contentData.metadata && this.contentData.metadata.title) ? this.contentData.metadata.title : 'Multiple Choice');
   };
+
+  this.registerDomElements();
+  
+
 };
 
 H5P.MultiChoice.prototype = Object.create(H5P.Question.prototype);

--- a/js/multichoice.js
+++ b/js/multichoice.js
@@ -462,6 +462,9 @@ H5P.MultiChoice = function (options, contentId, contentData) {
     }
   };
 
+  //Create question DOM on instantiation to calculate score accurately
+  this.registerDomElements();
+
   this.showAllSolutions = function () {
     if (solutionsVisible) {
       return;


### PR DESCRIPTION
- registerDomElements() is called upon instantiation to accurately calculate score of the the question. This is necessary for parent libraries, such as Interactive Video, because score calculation requires the question to exist in the DOM. 
- Before this change, this would cause users to lose score data upon leaving and coming back to a content such as interactive video, essentially forcing them to revisit every question they've answered in order to receive an accurate score. This change also fixes the issue of the endscreen of Interactive Video reflecting 0's on all scores related to multiple choice questions. 

More details on this issue are cited here:
https://h5p.org/node/547910
https://github.com/h5p/h5p-interactive-video/issues/154
